### PR TITLE
Fix linking

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -85,7 +85,7 @@ project "mk_sepi"
   targetname "sepi"
   buildoptions { "-Wno-deprecated-declarations" }
   files {"deps/sepi.c"}
-  
+
 -- Main Application
 project "mk_sqv"
   kind "ConsoleApp"
@@ -95,13 +95,14 @@ project "mk_sqv"
   objdir "BUILD/obj"
   targetname "sqv"
   includedirs {"src", "deps"}
+  libdirs { "BUILD" }
   links {
-    "mk_log:static",
-    "mk_ini:static",
-    "mk_stb:static",
-    "mk_hmm:static",
-    "mk_sepi:static",
-    "mk_sokol:static",    
+    "log:static",
+    "ini:static",
+    "stb:static",
+    "hmm:static",
+    "sepi:static",
+    "sokol:static",
   }
   files {
     "src/app.c",
@@ -160,4 +161,3 @@ newaction {
     os.execute("BUILD/sqv -i=" .. args_str)
   end
 }
-


### PR DESCRIPTION
Hi! Just wanted to checkout your viewer, looks like a nice project!
I cloned the repo and ran the commands as described in the readme but `make` failed during linking:
```
$ premake5 gmake2             
Building configurations...
Running action 'gmake2'...
Generated BUILD/mk_log.make...
Generated BUILD/mk_ini.make...
Generated BUILD/mk_sokol.make...
Generated BUILD/mk_hmm.make...
Generated BUILD/mk_stb.make...
Generated BUILD/mk_sepi.make...
Generated BUILD/mk_sqv.make...
Done (36ms).
$ make
==== Building mk_log (debug) ====
Creating obj/Debug/mk_log
log.c
Linking mk_log
==== Building mk_ini (debug) ====
Creating obj/Debug/mk_ini
ini.c
Linking mk_ini
==== Building mk_sokol (debug) ====
Creating obj/Debug/mk_sokol
sokol.c
Linking mk_sokol
==== Building mk_hmm (debug) ====
Creating obj/Debug/mk_hmm
hmm.c
Linking mk_hmm
==== Building mk_stb (debug) ====
Creating obj/Debug/mk_stb
stb.c
Linking mk_stb
==== Building mk_sepi (debug) ====
Creating obj/Debug/mk_sepi
sepi.c
Linking mk_sepi
==== Building mk_sqv (debug) ====
Creating obj/Debug/mk_sqv
app.c
draw_bsp.c
draw_model.c
draw_texture.c
draw_ui.c
Linking mk_sqv
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_log: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_log library ?
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_ini: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_ini library ?
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_stb: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_stb library ?
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_hmm: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_hmm library ?
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_sepi: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_sepi library ?
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmk_sokol: No such file or directory
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: have you installed the static version of the mk_sokol library ?
collect2: error: ld returned 1 exit status
make[1]: *** [mk_sqv.make:84: sqv] Error 1
make: *** [Makefile:78: mk_sqv] Error 2
```

Does a clean checkout from main work for you?

In any case, I've never used premake before, but it looks like the path that the static libraries ended up in (`./BUILD`) wasn't in the library search path and the names of the libraries were incorrect, all named like `mk_<x>` whereas the `.a` libs in BUILD were all just called `lib<x>.a. So made some changes to the premake config that made it work for me. Not sure if this the correct way though :) 